### PR TITLE
Add develop branch to conventional commits check triggers

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   conventional-commits-check:


### PR DESCRIPTION
Add the develop branch to the list of branches monitored by the conventional commits check during push and pull request events.