### PR TITLE
Add Apache License and update documentation

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -1,4 +1,4 @@
-name: Conventional Commits Check
+name: 'Check Conventional Commits format'
 
 on:
   push:

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,4 +1,4 @@
-name: semantic-release
+name: 'Semantic Release'
 on:
   push:
     branches:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2025 Saverio Mattia Merenda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# github-action
+# merendamattia/github-action
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Latest Release](https://img.shields.io/github/v/release/merendamattia/github-action?label=release)](https://github.com/merendamattia/github-action/releases)
+
+[![Actions Status](https://github.com/merendamattia/github-action/actions/workflows/check-docker-image.yaml/badge.svg)](https://github.com/merendamattia/github-action/actions)
+[![Actions Status](https://github.com/merendamattia/github-action/actions/workflows/check-latex-document.yaml/badge.svg)](https://github.com/merendamattia/github-action/actions)
+[![Actions Status](https://github.com/merendamattia/github-action/actions/workflows/conventional-commits-check.yaml/badge.svg)](https://github.com/merendamattia/github-action/actions)
+[![Actions Status](https://github.com/merendamattia/github-action/actions/workflows/semantic-release.yaml/badge.svg)](https://github.com/merendamattia/github-action/actions)
+
+
+A customizable GitHub Actions setup to streamline and automate development workflows. Includes a Makefile for easy usage and integration.
 
 Run `make` or `make help` to display this list of targets and their descriptions.
 
@@ -7,10 +18,15 @@ Full environment setup:
 make setup
 ```
 
-## Action supported:
-1. [Git Conventional Commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) using [pre-commit](https://pre-commit.com/).
-2. Git Conventional Commits check using [pre-commit](https://pre-commit.com/).
-3. [Git Semantic Release](https://dev.to/sahanonp/how-to-setup-semantic-release-with-github-actions-31f3) using [action-for-semantic-release](https://github.com/marketplace/actions/action-for-semantic-release).
-4. Auto Assign Pull Request by [kentaro-m/auto-assign-action](https://github.com/kentaro-m/auto-assign-action/tree/v2.0.0/).
-5. Check Docker Image building.
-6. Check LaTeX document building by [xu-cheng/latex-action](https://github.com/xu-cheng/latex-action/tree/v3/).
+## Action supported
+1. Git Conventional Commits check using [pre-commit](https://pre-commit.com/).
+2. [Git Semantic Release](https://dev.to/sahanonp/how-to-setup-semantic-release-with-github-actions-31f3) using [action-for-semantic-release](https://github.com/marketplace/actions/action-for-semantic-release).
+3. Auto Assign Pull Request by [kentaro-m/auto-assign-action](https://github.com/kentaro-m/auto-assign-action/tree/v2.0.0/).
+4. Check Docker Image building.
+5. Check LaTeX document building by [xu-cheng/latex-action](https://github.com/xu-cheng/latex-action/tree/v3/).
+
+## Contributors
+
+<a href="https://github.com/merendamattia/github-action/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=merendamattia/github-action" />
+</a>


### PR DESCRIPTION
Incorporate the Apache License 2.0 into the project and enhance the README with the project name, action status badges, and updated workflow names for better clarity and visibility.