### PR TITLE
Enable skipKeywords in auto-assign configuration

### DIFF
--- a/.github/configs/auto-assign-pull-request-configs.yaml
+++ b/.github/configs/auto-assign-pull-request-configs.yaml
@@ -7,6 +7,7 @@ addAssignees: author
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - merendamattia
+  - Copilot
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
@@ -21,5 +22,5 @@ numberOfReviewers: 0
 # numberOfAssignees: 2
 
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
-# skipKeywords:
-#   - wip
+skipKeywords:
+  - wip


### PR DESCRIPTION
Add support for skipKeywords in the auto-assign configuration to allow specific keywords, such as "wip," to bypass the reviewer assignment process.