### PR TITLE
Update push branches for conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
+    branches: [main, master]
 
 jobs:
   conventional-commits:


### PR DESCRIPTION
Include the `master` branch in the conventional commits check to ensure proper validation during pushes.