### PR TITLE
Add Docker publish workflow for automated image builds

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,54 @@
+name: Docker Publish (simple)
+on:
+  workflow_run:
+    workflows: ["Semantic Release"]
+    types: [completed]
+  push:
+    branches: [deploy-on-docker-hub]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Checkout the repo at workflow run commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Determine tag to use
+        id: determine_tag
+        run: |
+          # Prefer a tag pointing to the checked-out commit
+          TAG=$(git tag --points-at HEAD | head -n1)
+          if [ -z "$TAG" ]; then
+            # fallback to head branch name (may be v1.2.3 if semantic-release pushed a branch/tag)
+            TAG="$HEAD_BRANCH"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "No tag found; failing"
+            exit 1
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        env:
+          DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
+          TAG: ${{ steps.determine_tag.outputs.tag }}
+        run: |
+          echo "Building $DOCKERHUB_REPO:$TAG"
+          docker build -t "$DOCKERHUB_REPO:$TAG" .
+          docker push "$DOCKERHUB_REPO:$TAG"

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -65,5 +65,6 @@ jobs:
           TAG: ${{ steps.determine_tag.outputs.tag }}
         run: |
           echo "Building $DOCKERHUB_REPO:$TAG"
-          docker build -t "$DOCKERHUB_REPO:$TAG" .
+          # Dockerfile is in the docker/ subfolder; use that as build context
+          docker build -f docker/Dockerfile -t "$DOCKERHUB_REPO:$TAG" docker/
           docker push "$DOCKERHUB_REPO:$TAG"

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,10 +1,8 @@
-name: Docker Publish (simple)
+name: 'Push docker image to Docker Hub'
 on:
   workflow_run:
     workflows: ["Semantic Release"]
     types: [completed]
-  push:
-    branches: [deploy-on-docker-hub]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -25,17 +25,32 @@ jobs:
 
       - name: Determine tag to use
         id: determine_tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          # Prefer a tag pointing to the checked-out commit
-          TAG=$(git tag --points-at HEAD | head -n1)
+          # 1) allow an explicit tag when manually dispatched
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          fi
+
+          # 2) fetch tags and use the latest tag by creation date
           if [ -z "$TAG" ]; then
-            # fallback to head branch name (may be v1.2.3 if semantic-release pushed a branch/tag)
+            # ensure tags are fetched
+            git fetch --tags --quiet
+            TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n1)
+          fi
+
+          # 3) fallback to HEAD_BRANCH if present
+          if [ -z "$TAG" ] && [ -n "$HEAD_BRANCH" ]; then
             TAG="$HEAD_BRANCH"
           fi
+
           if [ -z "$TAG" ]; then
             echo "No tag found; failing"
             exit 1
           fi
+
+          echo "Using tag: $TAG"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Log in to Docker Hub

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -9,7 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
@@ -35,7 +36,7 @@ jobs:
           if [ -z "$TAG" ]; then
             # ensure tags are fetched
             git fetch --tags --quiet
-            TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags | head -n1)
+            TAG=$(git for-each-ref --sort=-version:refname --format '%(refname:short)' refs/tags | head -n1)
           fi
 
           # 3) fallback to HEAD_BRANCH if present


### PR DESCRIPTION
Introduce a new workflow for automated Docker image builds and pushes to Docker Hub. Improve tag determination logic and specify the Dockerfile location in the build context for clarity. Update the workflow name for better understanding of the Docker publish process.